### PR TITLE
Add default tenant id to help distinguish multi-tenant accounts case

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,21 +355,23 @@ const delayedOperation = async () => {
 
 ### Global Configuration
 
-Provides a way to set global default configurations for token requests that will be used by all hooks in the library. This eliminates the need to pass the same configuration to multiple hooks across your application.
+Provides a way to set global default configurations for token requests and tenant ID that will be used by all hooks in the library. This eliminates the need to pass the same configuration to multiple hooks across your application.
 
 ```typescript
 import {
-  setDefaultSilentRequest,
+  msalConfig,
   useGetToken,
   useFetchWithToken,
 } from '@joouis/msal-react-utility';
 
-// Set global default configuration once at the application startup
-setDefaultSilentRequest({
+// Set global default configurations once at the application startup
+msalConfig.setDefaultSilentRequest({
   scopes: ['User.Read', 'api://my-app/access'],
   authority: 'https://login.microsoftonline.com/tenant-id',
   forceRefresh: false,
 });
+
+msalConfig.setDefaultTenantId('your-tenant-id');
 
 // In components - hooks will use the global configuration automatically
 const MyComponent = () => {
@@ -384,19 +386,25 @@ const MyComponent = () => {
 
   // Implementation...
 };
+
+// Reset all configurations if needed
+msalConfig.reset();
 ```
 
 **Global Configuration Functions:**
 
 - `setDefaultSilentRequest(config: SilentRequest): void` - Sets the default SilentRequest configuration for all token requests
-- `getDefaultSilentRequest(): SilentRequest | undefined` - Gets the current global configuration
+- `getDefaultSilentRequest(): SilentRequest | undefined` - Gets the current global SilentRequest configuration
+- `setDefaultTenantId(tenantId: string): void` - Sets the default tenant ID for all requests
+- `getDefaultTenantId(): string | undefined` - Gets the current global tenant ID
+- `reset(): void` - Resets all global configurations to their default values
 
 **Configuration Hierarchy:**
 
 When using hooks, configurations are applied in the following order of precedence:
 
 1. Default values (`scopes: ['User.Read']`, `prompt: 'select_account'`)
-2. Global configuration (set via `setDefaultSilentRequest`)
+2. Global configuration (set via `setDefaultSilentRequest` and `setDefaultTenantId`)
 3. Hook-level configuration (passed directly to hooks like `useGetToken`)
 4. Call-level configuration (passed when calling functions like `getToken()`)
 
@@ -405,8 +413,9 @@ When using hooks, configurations are applied in the following order of precedenc
 - Reduces code duplication across components
 - Centralizes authentication configuration
 - Makes codebase more maintainable
-- Allows easy updates to scopes or authorities
+- Allows easy updates to scopes, authorities, or tenant IDs
 - No context provider required
+- Flexible configuration reset capability
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,32 @@ const MyComponent = ({ onSubmit }: { onSubmit: (data: FormData) => void }) => {
 - Solves the issue of creating new function references in render
 - Similar to the upcoming React `useEvent` hook
 
+#### useAutoSetActiveAccount
+
+Automatically sets the active account based on configured tenant ID.
+
+```typescript
+import { useAutoSetActiveAccount } from '@joouis/msal-react-utility';
+
+const App = () => {
+  // Call the hook at a high level in your app
+  useAutoSetActiveAccount();
+
+  return (
+    // Your app content
+  );
+};
+```
+
+**Notes:**
+
+- Automatically sets the active MSAL account based on:
+  1. Account matching the configured default tenant ID
+  2. First available account if no tenant ID match or no default tenant configured
+- Useful for multi-tenant applications where you need to ensure operations use the correct tenant
+- No configuration required - works with global tenant ID configuration
+- Best used near the root of your application
+
 ### Utilities
 
 #### getResponseData

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joouis/msal-react-utility",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The utility package for @azure/msal-react.",
   "keywords": [
     "azure",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,7 @@
 import type { SilentRequest } from '@azure/msal-browser';
 
 interface GlobalConfig {
+  defaultTenantId?: string;
   defaultSilentRequest?: SilentRequest;
 }
 
@@ -25,17 +26,17 @@ class MSALConfigSingleton {
     return this.config.defaultSilentRequest;
   }
 
+  public setDefaultTenantId(tenantId: string): void {
+    this.config.defaultTenantId = tenantId;
+  }
+
+  public getDefaultTenantId(): string | undefined {
+    return this.config.defaultTenantId;
+  }
+
   public reset(): void {
     this.config = {};
   }
 }
 
 export const msalConfig = MSALConfigSingleton.getInstance();
-
-export const setDefaultSilentRequest = (config: SilentRequest): void => {
-  msalConfig.setDefaultSilentRequest(config);
-};
-
-export const getDefaultSilentRequest = (): SilentRequest | undefined => {
-  return msalConfig.getDefaultSilentRequest();
-};

--- a/src/hooks/useAutoSetActiveAccount.ts
+++ b/src/hooks/useAutoSetActiveAccount.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+import { useMsal } from '@azure/msal-react';
+import { msalConfig } from '../globalConfig';
+
+export const useAutoSetActiveAccount = () => {
+  const { instance, accounts } = useMsal();
+
+  React.useEffect(() => {
+    const activeAccount = instance.getActiveAccount();
+    const defaultTenantId = msalConfig.getDefaultTenantId();
+    if (defaultTenantId && activeAccount?.tenantId !== defaultTenantId) {
+      const validAccount = accounts.find((a) => a.tenantId === defaultTenantId);
+      if (validAccount) {
+        instance.setActiveAccount(validAccount);
+      }
+    } else if (!activeAccount && accounts[0]) {
+      instance.setActiveAccount(accounts[0]);
+    }
+  }, [instance, accounts]);
+};

--- a/src/hooks/useGetToken.ts
+++ b/src/hooks/useGetToken.ts
@@ -13,13 +13,17 @@ import { useEventCallback } from './useEventCallback';
 import { sleep } from '../utilities/sleep';
 import { parseJwtToken } from '../utilities/parseJwtToken';
 import { TokenType, type GetToken } from '../inteface';
-import { getDefaultSilentRequest } from '../globalConfig';
+import { msalConfig } from '../globalConfig';
 
 // User should have logged in before calling this hook
 export const useGetToken = (defaultRequestConfigs?: SilentRequest) => {
   const { instance, inProgress, accounts } = useMsal();
   const inProgressRef = useRef(inProgress);
-  const account = accounts[0];
+
+  const defaultTenantId = msalConfig.getDefaultTenantId();
+  const validAccount = defaultTenantId
+    ? accounts.find((a) => a.tenantId === defaultTenantId)
+    : accounts[0];
 
   useEffect(() => {
     inProgressRef.current = inProgress;
@@ -34,12 +38,12 @@ export const useGetToken = (defaultRequestConfigs?: SilentRequest) => {
     const configs = {
       scopes: ['User.Read'],
       prompt: 'select_account',
-      ...getDefaultSilentRequest(),
+      ...msalConfig.getDefaultSilentRequest(),
       ...defaultRequestConfigs,
       ...requestConfigs,
     };
     try {
-      const activeAccount = instance.getActiveAccount() || account;
+      const activeAccount = instance.getActiveAccount() || validAccount;
       if (!activeAccount) {
         await instance.loginRedirect();
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './hooks/useAutoSetActiveAccount';
 export * from './hooks/useEventCallback';
 export * from './hooks/useFetchWithStatus';
 export * from './hooks/useFetchWithToken';


### PR DESCRIPTION
This pull request introduces support for setting a default tenant ID in the `@joouis/msal-react-utility` library, enhances global configuration management, and simplifies the codebase. The most important changes include adding methods for managing the default tenant ID, updating related documentation, and improving the `useGetToken` hook to respect the new tenant ID configuration.

### Enhancements to Global Configuration:
* Added `setDefaultTenantId` and `getDefaultTenantId` methods to the `MSALConfigSingleton` class to allow setting and retrieving a default tenant ID globally. (`src/globalConfig.ts`, [src/globalConfig.tsR29-L41](diffhunk://#diff-4d1d58fbe86d554cb3231c94d642aa465aa65c182d2e8630b8c5718638e334ddR29-L41))
* Updated the `reset` method in `MSALConfigSingleton` to clear the new `defaultTenantId` field. (`src/globalConfig.ts`, [src/globalConfig.tsR29-L41](diffhunk://#diff-4d1d58fbe86d554cb3231c94d642aa465aa65c182d2e8630b8c5718638e334ddR29-L41))

### Updates to Documentation:
* Updated the `README.md` to include examples and explanations for the new `setDefaultTenantId` and `reset` methods, and clarified the configuration hierarchy to include tenant ID. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L358-R375) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R389-R407) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L408-R418)

### Improvements to `useGetToken` Hook:
* Modified the `useGetToken` hook to use the default tenant ID when selecting the appropriate account, improving multi-tenant support. (`src/hooks/useGetToken.ts`, [[1]](diffhunk://#diff-0613f2371d87ae1878041185117d7a91e77abbc199c0a2ae5905ce35de4cb897L16-R26) [[2]](diffhunk://#diff-0613f2371d87ae1878041185117d7a91e77abbc199c0a2ae5905ce35de4cb897L37-R46)

### Codebase Simplification:
* Removed redundant exports for `setDefaultSilentRequest` and `getDefaultSilentRequest` in favor of using the `msalConfig` singleton directly. (`src/globalConfig.ts`, [src/globalConfig.tsR29-L41](diffhunk://#diff-4d1d58fbe86d554cb3231c94d642aa465aa65c182d2e8630b8c5718638e334ddR29-L41))

### Version Update:
* Incremented the package version from `2.4.0` to `2.4.1` to reflect the new features and improvements. (`package.json`, [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))